### PR TITLE
fix GitHub Actions deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
     "alpinejs": "^3.14.6",
     "astro": "^5.0.2",
     "tailwindcss": "^3.4.16"
-  }
+  },
+  "packageManager": "pnpm@10.0.0-beta.1+sha512.629de0531b9ae9a3f8e372d014ef8f5a57906d9a48095ced54bbfbd246b4136381478032c8d13819fd1eedde8330517a799ea6756eedd9a136e36524fa3083cf"
 }


### PR DESCRIPTION
GitHub expects to be notified about which (nodejs) package manager we are using; whether from actions.yml or package.json

I prefered the package.json procedure, using `corepack use pnpm` to add packageManager option at the package manifesto.