### PR TITLE
analytics: add umami tracking code

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,7 @@ const { title } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="description" content="Ecuador In Tech" />
     <meta name="viewport" content="width=device-width" />
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="cb063bf5-5bb2-443b-ba30-e0447966a426"></script>
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link


### PR DESCRIPTION
As discussed at #38 , we should be implementing a freedom-respecting analytics platform. Our platform of choice was [umami](https://umami.is/).

I setup a hobby account, using european union datacenters.

f51f36f, I put tracking code inside the HTML header of src/layouts/Layout.astro

PLEASE (!!!) If you want to get involve in this PR, write commits as atomically as possible, so we can revert back if we need it.