### PR TITLE
fix: change image extension in commitments

### DIFF
--- a/src/assets/commitments.json
+++ b/src/assets/commitments.json
@@ -4,7 +4,7 @@
 		"description": "Organizar eventos y actividades que permitan a los miembros de diferentes comunidades conocerse y colaborar.",
 		"cta": "Próximos eventos",
 		"link": "/events",
-		"image": "/images/codefest_conference.jpg",
+		"image": "/images/codefest_conference.webp",
 		"icon": "M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
 	},
 	{


### PR DESCRIPTION
At ImageMagick PR, we converted all the binary images there were in the repo. In previous PR, one of the converted images was reference, but at the previous extension.

This fixes it.